### PR TITLE
Add a non zero exit code on connection failures

### DIFF
--- a/snrtorrd.py
+++ b/snrtorrd.py
@@ -135,7 +135,7 @@ try:
     mysocket.settimeout(options['timeout'])
 except:
     print("Failed to connect....exit")
-    exit()   
+    exit(110)   
 print("Socket open...")
 
 uri = '/%d/%s' % (int(time.time()), 'W/F')


### PR DESCRIPTION
Very very minor thing, but it bit me when I was putting some error handling around it when I had some network issues, I didn't get any notifications letting me know it'd exploded in a ball of fire.

Went with 110 which if I recall correct is connection timed out, seemed reasonable enough to use that.

Thanks for the scripts 😸